### PR TITLE
Fix coverage collection

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,12 +3,12 @@ module.exports = {
   setupFiles: ['./jest.setup.js'],
   testPathIgnorePatterns: [
     '/node_modules/',
+    '/coverage/'
   ],
   testMatch: ['**/test/*Test.js'],
   collectCoverageFrom: [
-    "**/*.{js,jsx}",
-    "!**/node_modules/**",
-    "!**/coverage/**"
+    "**/src/**/*.{js,jsx}",
+    "!**/src/registerServiceWorker.{js,jsx}"
   ],
   coverageThreshold: {
     global: {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
-
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
-  ReactDOM.unmountComponentAtNode(div);
-});


### PR DESCRIPTION
# Description
This PR fixes the coverage collection settings to:
* Not include tests config files
* Not include registerServiceWorker.js

Also removes `App.test.js` as it was not being run, and it was adding to the coverage.

<img width="842" alt="screen shot 2018-03-12 at 5 20 38 pm" src="https://user-images.githubusercontent.com/11748696/37314439-ba00e996-2619-11e8-9c95-2a1d07acedff.png">
